### PR TITLE
Kits can Make High Impact Ammo for Scout

### DIFF
--- a/code/modules/cm_tech/techs/marine/tier2/enhanced_antibiologicals.dm
+++ b/code/modules/cm_tech/techs/marine/tier2/enhanced_antibiologicals.dm
@@ -170,6 +170,7 @@
 	.[/obj/item/ammo_magazine/pistol/mod88] =  /obj/item/ammo_magazine/pistol/mod88/penetrating
 	.[/obj/item/ammo_magazine/revolver] =  /obj/item/ammo_magazine/revolver/penetrating
 	.[/obj/item/ammo_magazine/rocket] = /obj/item/ammo_magazine/rocket/ap
+	.[/obj/item/ammo_magazine/rifle/m4ra] = /obj/item/ammo_magazine/rifle/m4ra/impact
 
 /obj/item/ammo_kit/toxin
 	name = "toxin ammo kit"
@@ -187,6 +188,7 @@
 	.[/obj/item/ammo_magazine/pistol/mod88] =  /obj/item/ammo_magazine/pistol/mod88/toxin
 	.[/obj/item/ammo_magazine/revolver] =  /obj/item/ammo_magazine/revolver/toxin
 	.[/obj/item/ammo_magazine/rocket] = /obj/item/ammo_magazine/rocket/ap
+	.[/obj/item/ammo_magazine/rifle/m4ra] = /obj/item/ammo_magazine/rifle/m4ra/impact
 
 /obj/item/ammo_kit/ap
 	name = "armor-piercing ammo kit"
@@ -202,5 +204,6 @@
 	.[/obj/item/ammo_magazine/revolver] =  /obj/item/ammo_magazine/revolver/marksman
 	.[/obj/item/ammo_magazine/rocket] = /obj/item/ammo_magazine/rocket/ap
 	.[/obj/item/ammo_magazine/rifle/m40_sd] = /obj/item/ammo_magazine/rifle/m40_sd/ap
+	.[/obj/item/ammo_magazine/rifle/m4ra] = /obj/item/ammo_magazine/rifle/m4ra/impact
 	.[/obj/item/explosive/grenade/HE] = /obj/item/explosive/grenade/HE/m15
 	.[/obj/item/explosive/grenade/HE/m15] = /obj/item/explosive/grenade/HE/PMC

--- a/code/modules/cm_tech/techs/marine/tier2/enhanced_antibiologicals.dm
+++ b/code/modules/cm_tech/techs/marine/tier2/enhanced_antibiologicals.dm
@@ -170,7 +170,6 @@
 	.[/obj/item/ammo_magazine/pistol/mod88] =  /obj/item/ammo_magazine/pistol/mod88/penetrating
 	.[/obj/item/ammo_magazine/revolver] =  /obj/item/ammo_magazine/revolver/penetrating
 	.[/obj/item/ammo_magazine/rocket] = /obj/item/ammo_magazine/rocket/ap
-	.[/obj/item/ammo_magazine/rifle/m4ra] = /obj/item/ammo_magazine/rifle/m4ra/impact
 
 /obj/item/ammo_kit/toxin
 	name = "toxin ammo kit"
@@ -188,7 +187,6 @@
 	.[/obj/item/ammo_magazine/pistol/mod88] =  /obj/item/ammo_magazine/pistol/mod88/toxin
 	.[/obj/item/ammo_magazine/revolver] =  /obj/item/ammo_magazine/revolver/toxin
 	.[/obj/item/ammo_magazine/rocket] = /obj/item/ammo_magazine/rocket/ap
-	.[/obj/item/ammo_magazine/rifle/m4ra] = /obj/item/ammo_magazine/rifle/m4ra/impact
 
 /obj/item/ammo_kit/ap
 	name = "armor-piercing ammo kit"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -896,7 +896,7 @@
 	name = "A19 high velocity impact bullet"
 	flags_ammo_behavior = AMMO_BALLISTIC
 
-	damage = BULLET_DAMAGE_TIER_8
+	damage = BULLET_DAMAGE_TIER_10
 	accuracy = -HIT_ACCURACY_TIER_2
 	scatter = -SCATTER_AMOUNT_TIER_8
 

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -63,7 +63,7 @@
 	name = "\improper A19 high velocity magazine (10x24mm)"
 	desc = "A magazine of A19 high velocity rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
 	icon_state = "m4ra"
-	default_ammo = /datum/ammo/bullet/rifle
+	default_ammo = /datum/ammo/bullet/rifle/m4ra
 	max_rounds = 24
 	gun_type = /obj/item/weapon/gun/rifle/m4ra
 


### PR DESCRIPTION
## Changelog

:cl: Anclandor

tweak: AP ammo kits now make High Impact ammo when used on scout rifle.  

tweak: High Impact ammo buffed to damage tier 10, one less that normal scout ammo, which is damage tier 11

Bugfix: Base scout mags were using base rifle ammo rather than scout rifle ammo (unless there was a hidden thing going on I don't understand), anyway, fixed this

/:cl:
